### PR TITLE
Upgrade CSP to Perspective 3.0.3

### DIFF
--- a/cpp/csp/core/Time.h
+++ b/cpp/csp/core/Time.h
@@ -360,7 +360,7 @@ public:
     static Time fromString( const std::string & );
 
     static Time NONE() { return Time( -1 ); }
-    static Time MIN()  { return Time( 0, 0, 0 ); }
+    static Time MIN_VALUE()  { return Time( 0, 0, 0 ); }
 
 private:
     Time( int64_t raw );

--- a/csp/tests/impl/test_dataframe.py
+++ b/csp/tests/impl/test_dataframe.py
@@ -134,10 +134,13 @@ class TestCspDataFrame(unittest.TestCase):
         starttime = datetime(2021, 4, 26)
         endtime = starttime + timedelta(seconds=10)
 
-        _ = df.to_perspective(starttime, endtime)
+        server = perspective.Server()
+        client = server.new_local_client()
+
+        _ = df.to_perspective(client, starttime, endtime)
 
         # realtime
-        widget = df.to_perspective(datetime.utcnow(), endtime=timedelta(seconds=30), realtime=True)
+        widget = df.to_perspective(client, datetime.utcnow(), endtime=timedelta(seconds=30), realtime=True)
         import time
 
         time.sleep(1)


### PR DESCRIPTION

Specific modifications done to CSP for this change:
* `csp/dataframe.py`: The `to_perspective` function now must take a `Client` object to construct the `Table`. 
* `csp/adapters/perspective.py`: The use of `PerspectiveManager` was changed to use of the new `Client`/`Server` classes.
* `csp/impl/pandas_perspective.py`: Perspective Table JSON update does not support direct `date` or `datetime` values now, as theses are not JSON serializable types. To work around this, the objects are directly translated to timestamp integers and sent to Perspective to be parsed into Perspective’s time types. `to_df` was rewritten to route through `PyArrow`,  but due to differences in how PyArrow chooses dtypes, there is some hackery around ordering of categories. We also removed `to_dict` and `to_numpy` because they were removed in the Perspective 3.0 migration.
* `csp/tests/impl/test_pandas_perspective.py` many tests were fixed to demonstrate changes that are needed to continue day-to-day use of `CspPerspectiveTable`. Some tests were not fixed due to an outstanding Perspective bug (https://github.com/finos/perspective/pull/2756).

The use of PyArrow to underly Perspective’s DataFrame support leads to some semantic changes. PyArrow is much more eager to set columns to `CategoricalDtype` instead of `StringDtype`. It also has different behavior regarding category ordering, and perhaps others still not uncovered after fixing the tests. 
